### PR TITLE
Create Groups Endpoint

### DIFF
--- a/Event/groups/routes.py
+++ b/Event/groups/routes.py
@@ -2,7 +2,7 @@
 Module for removing user from a group.
 """
 
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 from Event.models import Users, Groups
 from Event import db
 
@@ -49,3 +49,44 @@ def remove_group_member(group_id, user_id):
     db.session.commit()
 
     return jsonify({"message": "User removed from group successfully"}), 200
+
+
+@groups.route("/", methods=["POST"])
+def create_group():
+    """
+    Create a new group.
+
+    This route expects a JSON request containing a 'title' key to create a new group.
+    The 'title' is used to create a new group instance and insert it into the database.
+
+    Returns:
+        JSON response with information about the created group or an error message.
+    """
+    try:
+        # Attempt to extract JSON data from the incoming request.
+        data = request.get_json()
+
+        # Check if the 'title' key is present in the JSON data.
+        if "title" not in data:
+            return jsonify({"error": "Missing 'title' in request"}), 400
+
+        # Extract the 'title' from the JSON data.
+        title = data["title"]
+
+        # Create a new group instance with the provided 'title'.
+        new_group = Groups(title=title)
+
+        # Insert the new group into the database.
+        new_group.insert()
+
+        # Return a JSON response indicating successful group creation.
+        return (
+            jsonify(
+                {"message": "Group created successfully", "group": new_group.format()}
+            ),
+            201,
+        )
+
+    # Handle exceptions and return an error response if any occur.
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500


### PR DESCRIPTION
## Description:
it introduces a new endpoint, POST /api/groups, to our application. It allows users to create groups by providing a 'title' via a JSON request, which is then stored in the database.
## Changes Made:
- Introduced a new endpoint, /api/groups, to the groups route.
- Implemented the create_group function, responsible for handling POST requests to the new endpoint
- The endpoint returns a JSON response containing a success message along with the details of the created group.