### PR TITLE
fix wrong method of retrieving user and groups

### DIFF
--- a/Event/groups/routes.py
+++ b/Event/groups/routes.py
@@ -89,19 +89,19 @@ def remove_group_member(group_id, user_id):
     tuple: A tuple containing response message and status code.
     """
     # Retrieve the group and user from the database
-    group_id = Users.query.get(group_id)
-    user_id = Groups.query.get(user_id)
+    group = Groups.query.get(group_id)
+    user = Users.query.get(user_id)
 
     # Check if the group and user exist
-    if group_id is None or user_id is None:
+    if group is None or user is None:
         return jsonify({"error": "Group or user not found"}), 404
 
     # Check if the user is a member of the group
-    if user_id not in group_id.members:
+    if user not in group.members:
         return jsonify({"error": "User is not a member of the group"}), 400
 
     # Remove the user from the group
-    group_id.members.remove(user_id)
+    group.members.remove(user)
     db.session.commit()
 
     return jsonify({"message": "User removed from group successfully"}), 200


### PR DESCRIPTION
## Description:
 Fix wrong method of retrieving user and group ids.

## Changes Made:
 Renamed variables to avoid overwrite.
**Before:**
```python
    group_id = Users.query.get(group_id)
    user_id = Groups.query.get(user_id)
```
**After:**
```python
    group = Groups.query.get(group_id)
    user = Users.query.get(user_id)
```

## Related Issue:
Fixes #[ISSUE_NUMBER]

## Testing Done:
Curl and postman test will be added later

## Screenshots (if applicable):
Attach screenshots, if applicable, to showcase the newly implemented feature or bug fix.
