### PR TITLE
Fix return messages of add_user_to_group and remove_user_from_group methods

### DIFF
--- a/Event/groups/routes.py
+++ b/Event/groups/routes.py
@@ -17,9 +17,13 @@ def add_user_to_group(groupId, userId):
         group = query_one_filtered(Groups,id=groupId)
         user = query_one_filtered(Users,id=userId)
 
-        # Check if the group and user exist
-        if group is None or user is None:
-            return jsonify({"error": "Group or user not found"}), 404
+        # Check if the group exist
+        if group is None:
+            return jsonify({"error": "Group not found"}), 404
+
+        # Check if the user exist
+        if user is None:
+            return jsonify({"error": "User not found"}), 404
 
         newgroup=user.user_groups
         if group.id in [group.id for group in newgroup ]:
@@ -146,15 +150,20 @@ def remove_user_from_group(group_id, user_id):
     user_id (str): The ID of the user to be removed from the group.
 
     Returns:
-    tuple: A tuple containing response message and status code.
+    A JSON response depending on the outcome of the method.
     """
     try:
-        # Check if the group and user exist in the database
+        # Retrieve group and user ids
         group = query_one_filtered(Groups,id=group_id)
         user = query_one_filtered(Users,id=user_id)
 
-        if group is None or user is None:
-            return jsonify({"message": "Group or user not found"}), 404
+        # Check if group exist
+        if group is None:
+            return jsonify({"message": "Group not found"}), 404
+
+        # Check if the user exist
+        if user is None:
+            return jsonify({"error": "User not found"})
 
         user_groups=user.user_groups
         if group_id not in [group.id for group in user_groups ]:


### PR DESCRIPTION
## Description:
When testing this method with the correct group_id and wrong user_id. The response was: 
```json
{"error": "Group or user not found"}
```
 which is correct but rather vague in what is not found. Group or User? So I added a check that will return a precise message.

## Changes Made:
Segmented both user_id and group_id checks.

## Related Issue:
Fixes #[ISSUE_NUMBER]

## Testing Done:
### add_user_to_group
**Before:** ```https://www.postman.com/kevinkoech357/workspace/event-app/request/29637783-bd27aa85-6297-4bbb-89d6-a837d2d0ec94?action=share&creator=29637783&ctx=documentation```
**After:**
```bash
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend$ curl -X POST http://127.0.0.1:5000/api/groups/group2_id/members/dragon
{
  "error": "User not found"
}
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend$ curl -X POST http://127.0.0.1:5000/api/groups/group1_id/members/dragon
{
  "error": "Group not found"
}
```
### remove_user_from_group
**Before:**
```bash
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend$ curl -X DELETE http://127.0.0.1:5000/api/groups/group2_id/members/dragonfly
{
  "error": "Group or user not found"
}
```
**After**
```bash
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend$ curl -X DELETE http://127.0.0.1:5000/api/groups/group2_id/members/dragonfly
{
  "error": "User not found"
}
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend$ curl -X DELETE http://127.0.0.1:5000/api/groups/group1_id/members/dragonfly
{
  "message": "Group not found"
}
```

## Screenshots (if applicable):
Attach screenshots, if applicable, to showcase the newly implemented feature or bug fix.
