### PR TITLE
Add get_all_groups method

### DIFF
--- a/Event/groups/routes.py
+++ b/Event/groups/routes.py
@@ -346,6 +346,7 @@ def delete_group(group_id):
                 }
                 ), 400
 
+
 # Get all groups available
 @groups.route("/", methods=["GET"])
 def get_all_groups():
@@ -355,7 +356,7 @@ def get_all_groups():
     Returns:
         JSON response with a list of group details.
     """
-    #is_logged_in(session)
+    is_logged_in(session)
     try:
         # Query the database to retrieve all groups
         all_groups = Groups.query.all()


### PR DESCRIPTION
## Description:
This will add a get_all_groups route that will return all details of groups in the database.

## Changes Made:
Add a method to get all groups.

## Related Issue:
Fixes #[ISSUE_NUMBER]

## Testing Done:
```bash
(env) kevinkoech357@kevinkoech:~/Personal/HNGx/delete_endpoint/my_acc/main/Spitfire-events-backend/Event/user$ curl -X GET http://127.0.0.1:5000/api/groups<!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="http://127.0.0.1:5000/api/groups/">http://127.0.0.1:5000/api/groups/</a>. If not, click the link.
```
```bash
127.0.0.1 - - [24/Sep/2023 12:41:43] "GET /api/groups HTTP/1.1" 308 -
127.0.0.1 - - [24/Sep/2023 12:42:31] "GET /api/groups HTTP/1.1" 308 -
127.0.0.1 - - [24/Sep/2023 12:42:33] "GET /api/groups HTTP/1.1" 308 -
127.0.0.1 - - [24/Sep/2023 12:42:34] "GET /api/groups HTTP/1.1" 308 -
```

## Screenshots (if applicable):
![Screenshot_20230924_124333](https://github.com/hngx-org/Spitfire-events-backend/assets/102515005/1436f329-2aed-4894-b389-254ab0ec3196)

